### PR TITLE
[01/30] URL공유 버튼 (복사, Toast 5초 모션 )

### DIFF
--- a/src/components/common/Toast/Toast.jsx
+++ b/src/components/common/Toast/Toast.jsx
@@ -1,21 +1,74 @@
+import { useState, useEffect, useRef } from 'react';
 import checkIcon from '@/assets/images/common/icon-check.svg';
 import closeIcon from '@/assets/images/common/icon-close.svg';
 import styles from './Toast.module.css';
 
+const AUTO_CLOSE_MS = 5000;
+const FADE_DURATION_MS = 300;
+
 /**
  * URL 공유 클릭에 대한 피드백을 표시하는 토스트 메시지 컴포넌트
+ * 5초 후 자동으로 사라지며, 등장/퇴장 시 스무스한 페이드 애니메이션 적용
  *
+ * @param {Object} props
+ * @param {() => void} [props.onClose] - 닫기 버튼 클릭 시 호출되는 콜백
  * @return {JSX.Element} URL 복사 성공 메시지와 닫기 버튼을 포함한 토스트 UI
  */
-function Toast() {
+function Toast({ onClose }) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isExiting, setIsExiting] = useState(false);
+  const autoCloseTimerRef = useRef(null);
+  const exitTimerRef = useRef(null);
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    const showTimer = requestAnimationFrame(() => {
+      requestAnimationFrame(() => setIsVisible(true));
+    });
+    return () => cancelAnimationFrame(showTimer);
+  }, []);
+
+  const handleClose = () => {
+    if (isExiting) return;
+    if (autoCloseTimerRef.current) {
+      clearTimeout(autoCloseTimerRef.current);
+      autoCloseTimerRef.current = null;
+    }
+    setIsExiting(true);
+    exitTimerRef.current = setTimeout(() => {
+      onCloseRef.current?.();
+    }, FADE_DURATION_MS);
+  };
+
+  useEffect(() => {
+    if (!isVisible) return;
+    autoCloseTimerRef.current = setTimeout(handleClose, AUTO_CLOSE_MS);
+    return () => {
+      if (autoCloseTimerRef.current) clearTimeout(autoCloseTimerRef.current);
+      if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- handleClose 의존 시 5초 타이머가 매 렌더마다 리셋됨
+  }, [isVisible]);
+
+  const containerClass = [
+    styles.toastContainer,
+    isVisible && !isExiting && styles.visible,
+    isExiting && styles.exiting,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div className={styles.toastContainer}>
+    <div className={containerClass}>
       <div className={styles.toast}>
         <div className={styles.toastText}>
           <img src={checkIcon} alt="" />
           <p>URL이 복사 되었습니다.</p>
         </div>
-        <button className={styles.toastCloseButton}>
+        <button type="button" className={styles.toastCloseButton} onClick={handleClose} aria-label="닫기">
           <img src={closeIcon} alt="" />
         </button>
       </div>

--- a/src/components/common/Toast/Toast.module.css
+++ b/src/components/common/Toast/Toast.module.css
@@ -1,8 +1,26 @@
 .toastContainer {
-  padding: 0 20px;
-  width: 100%;
-  height: 64px;
-  max-width: 524px;
+  position: fixed;
+  width: 524px;
+  bottom: 70px;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  z-index: 1000;
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
+}
+
+.toastContainer.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toastContainer.exiting {
+  opacity: 0;
+  transform: translateY(12px);
 }
 
 .toast {
@@ -12,6 +30,7 @@
   padding: 19px 30px;
   background-color: rgb(0 0 0 / 80%);
   border-radius: 8px;
+
 }
 
 .toastText {
@@ -28,4 +47,14 @@
   justify-content: center;
   width: 24px;
   height: 24px;
+}
+
+
+@media (max-width: 767px) {
+  .toastContainer {
+    width: calc(100% - 48px);
+    bottom: 88px;
+    left: 20px;
+    right: 20px;
+  }
 }

--- a/src/components/feature/PostDetail/LinkShare.jsx
+++ b/src/components/feature/PostDetail/LinkShare.jsx
@@ -1,17 +1,35 @@
 import { useState } from 'react';
 import styles from './LinkShare.module.css';
+import Toast from '@/components/common/Toast/Toast';
 
 /**
  * 카카오톡 / URL 공유 드롭다운 컴포넌트
  * - 상태 ( active ) 에 따라 메뉴 노출 및 클래스 토글
+ * - URL 공유 클릭 시 클립보드에 URL 복사 후 토스트 표시
  *
  * @return {JSX.Element} 공유 버튼과 드롭다운 메뉴 ( 카카오톡, URL ) 리스트
  */
 function LinkShare() {
   const [active, setActive] = useState(false);
+  const [showToast, setShowToast] = useState(false);
 
   const handleClick = () => {
     setActive(!active);
+  };
+
+  const handleUrlShareClick = async () => {
+    const url = window.location.href;
+    try {
+      await navigator.clipboard.writeText(url);
+      setActive(false);
+      setShowToast(true);
+    } catch (err) {
+      console.error('클립보드 복사 실패:', err);
+    }
+  };
+
+  const handleCloseToast = () => {
+    setShowToast(false);
   };
 
   // active : true 드롭다운 메뉴 활성화 / false 드롭다운 메뉴 비활성화
@@ -30,9 +48,12 @@ function LinkShare() {
           <button className={styles.linkMenuButton}>카카오톡 공유</button>
         </li>
         <li>
-          <button className={styles.linkMenuButton}>URL 공유</button>
+          <button type="button" className={styles.linkMenuButton} onClick={handleUrlShareClick}>
+            URL 공유
+          </button>
         </li>
       </ul>
+      {showToast && <Toast onClose={handleCloseToast} />}
     </div>
   );
 }

--- a/src/components/feature/PostDetail/LinkShare.module.css
+++ b/src/components/feature/PostDetail/LinkShare.module.css
@@ -3,7 +3,7 @@
 }
 
 .linkMenu {
-  display: none;
+  display: flex;
   flex-direction: column;
   justify-content: center;
   padding: 10px 0;
@@ -14,10 +14,21 @@
   border: 1px solid var(--color-gray-300);
   border-radius: 8px;
   background-color: #fff;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px);
+  transition:
+    opacity 0.2s ease-out,
+    transform 0.2s ease-out,
+    visibility 0.2s;
+  pointer-events: none;
 }
 
 .linkMenu.active {
-  display: flex;
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
 .linkMenu .linkMenuButton {


### PR DESCRIPTION
## 🔀 변경 사항
- [X] 신규 기능 추가 
- [ ] 버그 수정 
- [ ] 리펙토링
- [ ] 테스트 
- [ ] 문서 업데이트 
- [ ] 기타

## ✅ 체크리스트
- [X] dev 최신 내용 반영
- [X] 콘솔 에러 없음
- [X] 불필요한 console.log 제거

## 📌 작업 내용
- URL공유 버튼 클릭시 => 현재페이지 URL복사, Toast 5초 show, hidden 효과

## ⏭️ 다음 진행사항 (선택)
카카오톡 공유