### PR TITLE
[02/04] URL 복사 실패 시 alert안내

### DIFF
--- a/src/components/feature/PostDetail/LinkShare.jsx
+++ b/src/components/feature/PostDetail/LinkShare.jsx
@@ -118,6 +118,8 @@ function LinkShare({ recipient }) {
       setShowToast(true);
     } catch (err) {
       console.error('클립보드 복사 실패:', err);
+      setActive(false);
+      alert('URL 복사에 실패했습니다. 주소창에서 URL을 직접 복사해 주세요.');
     }
   };
 


### PR DESCRIPTION
## 🔀 변경 사항
- [X] 신규 기능 추가 
- [ ] 버그 수정 
- [ ] 리펙토링
- [ ] 테스트 
- [ ] 문서 업데이트 
- [ ] 기타

## ✅ 체크리스트
- [X] dev 최신 내용 반영
- [X] 콘솔 에러 없음
- [X] 불필요한 console.log 제거

## 📌 작업 내용
-  URL 복사 실패 시: navigator.clipboard 실패하면 alert로
  "URL 복사에 실패했습니다. 주소창에서 URL을 직접 복사해 주세요." 
  안내 후 드롭다운을 닫도록 처리했습니다.

## 🧩 관련 이슈 / 고민


## 🖼️ 참고 (선택)


## ⏭️ 다음 진행사항 (선택)